### PR TITLE
Made property filter component configurable via App Builder

### DIFF
--- a/force-app/main/default/flexipages/Property_Explorer.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Property_Explorer.flexipage-meta.xml
@@ -2,6 +2,10 @@
 <FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <flexiPageRegions>
         <componentInstances>
+            <componentInstanceProperties>
+                <name>priceSliderMaxValue</name>
+                <value>1200000</value>
+            </componentInstanceProperties>
             <componentName>propertyFilter</componentName>
         </componentInstances>
         <name>left</name>

--- a/force-app/main/default/flexipages/Property_Finder.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Property_Finder.flexipage-meta.xml
@@ -2,6 +2,10 @@
 <FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <flexiPageRegions>
         <componentInstances>
+            <componentInstanceProperties>
+                <name>priceSliderMaxValue</name>
+                <value>1200000</value>
+            </componentInstanceProperties>
             <componentName>propertyFilter</componentName>
         </componentInstances>
         <name>left</name>

--- a/force-app/main/default/lwc/propertyFilter/propertyFilter.html
+++ b/force-app/main/default/lwc/propertyFilter/propertyFilter.html
@@ -13,14 +13,16 @@
                 value={searchKey}
                 onchange={handleSearchKeyChange}
             ></lightning-input>
+
             <lightning-slider
                 label="Max Price"
                 step="50000"
                 min="0"
-                max="1200000"
+                max={priceSliderMaxValue}
                 value={maxPrice}
                 onchange={handleMaxPriceChange}
             ></lightning-slider>
+
             <lightning-slider
                 label="Bedrooms"
                 step="1"
@@ -29,6 +31,7 @@
                 value={minBedrooms}
                 onchange={handleMinBedroomsChange}
             ></lightning-slider>
+
             <lightning-slider
                 label="Bathrooms"
                 step="1"

--- a/force-app/main/default/lwc/propertyFilter/propertyFilter.js
+++ b/force-app/main/default/lwc/propertyFilter/propertyFilter.js
@@ -1,14 +1,16 @@
-import { LightningElement, wire, track } from 'lwc';
+import { LightningElement, wire, track, api } from 'lwc';
 import { CurrentPageReference } from 'lightning/navigation';
 import { fireEvent } from 'c/pubsub';
 
 const DELAY = 350;
-const MAX_PRICE = 1200000;
 
 export default class PropertyFilter extends LightningElement {
+    // Set the price slider's max value via a parameter exposed in App Builder
+    @api priceSliderMaxValue;
+
     @track searchKey = '';
 
-    @track maxPrice = MAX_PRICE;
+    @track maxPrice = 0;
 
     @track minBedrooms = 0;
 
@@ -16,9 +18,14 @@ export default class PropertyFilter extends LightningElement {
 
     @wire(CurrentPageReference) pageRef;
 
+    connectedCallback() {
+        // Set the price slider to its max value
+        this.maxPrice = this.priceSliderMaxValue;
+    }
+
     handleReset() {
         this.searchKey = '';
-        this.maxPrice = MAX_PRICE;
+        this.maxPrice = this.priceSliderMaxValue;
         this.minBedrooms = 0;
         this.minBathrooms = 0;
         this.fireChangeEvent();

--- a/force-app/main/default/lwc/propertyFilter/propertyFilter.js-meta.xml
+++ b/force-app/main/default/lwc/propertyFilter/propertyFilter.js-meta.xml
@@ -5,4 +5,9 @@
     <targets>
         <target>lightning__AppPage</target>
     </targets>
+    <targetConfigs>
+      <targetConfig targets="lightning__AppPage">
+          <property name="priceSliderMaxValue" label="Max Value for Price Slider" type="Integer" default="1200000" required="true"/>
+      </targetConfig>
+  </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
I removed the hard-coded max value for the property price slider and replaced it with an App Builder param. This is a small code modification and adds a much needed example.