### PR TITLE
Fix UI data import in developer orgs

### DIFF
--- a/force-app/main/default/classes/SampleDataController.cls
+++ b/force-app/main/default/classes/SampleDataController.cls
@@ -1,14 +1,14 @@
 public with sharing class SampleDataController {
     @AuraEnabled
     public static void importSampleData() {
-            delete [SELECT Id FROM Case];
-            delete [SELECT Id FROM Property__c];
-            delete [SELECT Id FROM Broker__c];
-            delete [SELECT Id FROM Contact];
+        delete [SELECT Id FROM Case];
+        delete [SELECT Id FROM Property__c];
+        delete [SELECT Id FROM Broker__c];
+        delete [SELECT Id FROM Contact];
 
-            insertBrokers();
-            insertProperties();
-            insertContacts();
+        insertBrokers();
+        insertProperties();
+        insertContacts();
     }
 
     private static void insertBrokers() {

--- a/force-app/main/default/classes/SampleDataController.cls
+++ b/force-app/main/default/classes/SampleDataController.cls
@@ -1,7 +1,7 @@
 public with sharing class SampleDataController {
     @AuraEnabled
     public static void importSampleData() {
-        try {
+            delete [SELECT Id FROM Case];
             delete [SELECT Id FROM Property__c];
             delete [SELECT Id FROM Broker__c];
             delete [SELECT Id FROM Contact];
@@ -9,9 +9,6 @@ public with sharing class SampleDataController {
             insertBrokers();
             insertProperties();
             insertContacts();
-        } catch (Exception e) {
-            System.debug(e);
-        }
     }
 
     private static void insertBrokers() {


### PR DESCRIPTION
Cases are created when signing up to a developer org. Contact deletion fails if cases are not deleted in advance.